### PR TITLE
.clang-format 파일 추가

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle: LLVM
+AlignTrailingComments: 'true'
+AllowShortFunctionsOnASingleLine: None
+DerivePointerAlignment: 'false'
+IndentWidth: '4'
+PointerAlignment: Left
+
+...


### PR DESCRIPTION
Wiki의 컨벤션 내용 참고하여, 위키에 있는 스타일대로 포매팅이 되게끔 .clang-format 파일을 구성하였음

https://zed0.co.uk/clang-format-configurator/
해당 Generator 이용함

### 위 사이트에서 설명 다 펼치기
```javascript
Array.from(document.querySelectorAll('a')).slice(1).forEach(e=>e.href.includes('#') ? e.click() : void 0);
document.querySelector('#code').translate = false;
```

https://medicineyeh.wordpress.com/2017/07/13/clang-format-with-pragma/
위 사이트의 이슈처럼 `#pragma omp` 전처리기를 들여쓰기하지 않는 문제가 있어
해당 사이트에서 제시된 방법을 이용해서 윈도우 환경에서 구동될 수 있도록 Powershell script로 포매팅 호출 코드를 작성하였음

```bash
npm install -g clang-format
```

```powershell
(Get-Content $FilePath$ -Encoding utf8) -replace '#pragma omp', '//#pragma omp' | Set-Content $FilePath$ -Encoding utf8; clang-format $FilePath$ -i; (Get-Content $FilePath$ -Encoding utf8) -replace '// *#pragma omp', '#pragma omp' | Set-Content $FilePath$ -Encoding utf8
```

![image](https://user-images.githubusercontent.com/58779799/229364094-d52301fc-89ff-4622-ac64-b4f08a422a66.png)
`$FilePath$`는 대상 파일, `$ProjectFileDir$`은 현재 프로젝트 루트임
각자 IDE의 명령 호출 기능을 키바인드 해서 전처리기까지 포매팅 가능하게 사용할 수 있을 것으로 생각됨